### PR TITLE
Add Node WhatsApp bot with Express and venom-bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/whatsapp-bot/index.js
+++ b/whatsapp-bot/index.js
@@ -1,0 +1,42 @@
+const venom = require('venom-bot');
+const express = require('express');
+const app = express();
+
+app.use(express.json());
+
+// Inicia sessão do WhatsApp
+venom
+  .create({
+    session: 'minha-sessao', // nome da sessão
+    multidevice: true, // compatível com multi-dispositivo
+  })
+  .then((client) => start(client))
+  .catch((erro) => {
+    console.log(erro);
+  });
+
+function start(client) {
+  console.log('✅ WhatsApp conectado!');
+
+  // Receber mensagens
+  client.onMessage((message) => {
+    console.log(`Mensagem recebida de ${message.from}: ${message.body}`);
+
+    if (message.body.toLowerCase() === 'oi') {
+      client.sendText(message.from, 'Olá! Seja bem-vindo ao nosso atendimento 🤖');
+    }
+  });
+
+  // Enviar mensagem via API HTTP
+  app.post('/send', (req, res) => {
+    const { number, text } = req.body;
+    client
+      .sendText(`${number}@c.us`, text)
+      .then(() => res.send({ status: 'ok' }))
+      .catch((err) => res.status(500).send(err));
+  });
+
+  app.listen(3000, () => {
+    console.log('🚀 API rodando na porta 3000');
+  });
+}

--- a/whatsapp-bot/package.json
+++ b/whatsapp-bot/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "whatsapp-bot",
+  "version": "1.0.0",
+  "description": "Simple WhatsApp bot using venom-bot and Express",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "*",
+    "venom-bot": "*"
+  }
+}


### PR DESCRIPTION
## Summary
- add `.gitignore` to ignore `node_modules`
- add basic WhatsApp bot using `venom-bot` with Express API

## Testing
- `npm install express venom-bot` *(fails: 403 Forbidden)*
- `npm test`
- `node index.js` *(fails: Cannot find module 'venom-bot')*

------
https://chatgpt.com/codex/tasks/task_e_68934ad3549c832ca62560a390fcc2ea